### PR TITLE
feat: add basic i18n support

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- 懸浮設定切換鈕（左側圖示顯示測試結果） -->
     <button id="settings-toggle" class="settings-toggle" aria-expanded="false" aria-controls="settings-panel" title="開啟/關閉設定（Ollama 網址與模型）">
         <span id="settings-indicator" class="settings-indicator" aria-hidden="true">⏳</span>
-        ⚙️ 設定
+        <span id="settings-label">⚙️ 設定</span>
     </button>
 
     <!-- 懸浮設定面板 -->
@@ -21,6 +21,16 @@
             <button class="close-x" id="settings-close" aria-label="關閉設定">×</button>
         </div>
         <div class="settings-inner">
+            <div class="settings-row">
+                <label for="ui-lang" id="ui-lang-label">介面語言</label>
+                <div class="model-group">
+                    <select id="ui-lang">
+                        <option value="zh-TW">繁體中文</option>
+                        <option value="en">English</option>
+                    </select>
+                </div>
+            </div>
+
             <div class="settings-row">
                 <label for="ollama-url">Ollama API 網址（範例： http://localhost:11434 ）</label>
                 <div class="url-group">


### PR DESCRIPTION
## Summary
- add translation table and dynamic application of UI strings
- allow switching interface language via new selector in settings panel

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa815d92808327b18ad9ae1cccf652