### PR TITLE
Add i18n for app title

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const translations = {
         outputPlaceholder: '翻譯結果將顯示於此',
         translateBtn: '翻譯',
         swapBtn: '交換語言',
+        appTitle: 'LLM語言翻譯',
         settingsTitle: '設定',
         ollamaUrl: 'Ollama 連線網址',
         validate: '測試連線',
@@ -33,6 +34,7 @@ const translations = {
         outputPlaceholder: 'Translation result will appear here',
         translateBtn: 'Translate',
         swapBtn: 'Swap Languages',
+        appTitle: 'LLM Translator',
         settingsTitle: 'Settings',
         ollamaUrl: 'Ollama URL',
         validate: 'Test Connection',
@@ -79,6 +81,10 @@ const settingsLabel     = document.getElementById('settings-label');
 function applyTranslations(){
     const t = translations[currentLang] || translations['en'];
     document.documentElement.lang = currentLang;
+
+    const titleEl = document.getElementById('app-title');
+    if(titleEl) titleEl.textContent = t.appTitle;
+    document.title = t.appTitle;
 
     // UI elements
     document.getElementById('input-text').placeholder = t.inputPlaceholder;

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
     <div class="app" aria-live="polite">
         <!-- 上方工具列（左：標題｜中：語言選單） -->
         <header class="topbar">
-            <div class="title">LLM語言翻譯</div>
+            <div id="app-title" class="title"></div>
 
             <select id="source-lang" aria-label="來源語言">
                 <option value="auto">自動偵測</option>


### PR DESCRIPTION
## Summary
- Localize the top bar title by adding an `appTitle` entry to translations and applying it dynamically.
- Replace the hardcoded heading with an empty container for JS-injected text and update `document.title` accordingly.

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa88b12950832793ea850acf2cf6fb