### PR TITLE
feat: auto select interface language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # LLM-Translator
 Imitating the Google Translate page, but using an LLM (currently Ollama) for translation.
+
+## Features
+- Detects browser language on first visit and sets the interface language accordingly, falling back to English if the language is not supported.

--- a/src/app.js
+++ b/src/app.js
@@ -59,7 +59,23 @@ const translations = {
     }
 };
 
-let currentLang = localStorage.getItem('uiLang') || (navigator.language.startsWith('zh') ? 'zh-TW' : 'en');
+// 首次載入時偵測瀏覽器語言，若 i18n 不支援則使用英文
+function detectBrowserLanguage(){
+    const navLangs = navigator.languages && navigator.languages.length ? navigator.languages : [navigator.language];
+    for(const lang of navLangs){
+        if(translations[lang]) return lang;
+        const base = lang.split('-')[0];
+        const match = Object.keys(translations).find(l => l.split('-')[0] === base);
+        if(match) return match;
+    }
+    return 'en';
+}
+
+let currentLang = localStorage.getItem('uiLang');
+if(!currentLang){
+    currentLang = detectBrowserLanguage();
+    localStorage.setItem('uiLang', currentLang);
+}
 
 // 取得元素
 const settingsToggle = document.getElementById('settings-toggle');


### PR DESCRIPTION
## Summary
- detect browser language on first visit to set interface language
- fall back to English if unsupported
- document language detection feature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8baab9808327a16ba54af1c1e0bb